### PR TITLE
Note that TOML tables currently must be one line

### DIFF
--- a/slides.ipynb
+++ b/slides.ipynb
@@ -337,6 +337,8 @@
     "}\n",
     "```\n",
     "\n",
+    "(TOML 1.0 requires tables (dicts) to be one line. Future TOML versions will allow multi-line tables.)\n",
+    "\n",
     "Alternatively\n",
     "\n",
     "```toml\n",


### PR DESCRIPTION
TOML 1.0 does not support multiple line tables. Instead it expects one line tables.

That said, one giant line is hard for slides. Also the TOML spec has been changed to support multiple line tables (atm pending release)

So add a caveat below the code example explaining it.